### PR TITLE
[CRM-7] Listagem de usuários

### DIFF
--- a/app/Livewire/Admin/Users/Index.php
+++ b/app/Livewire/Admin/Users/Index.php
@@ -19,6 +19,8 @@ class Index extends Component
 
     public ?string $search = null;
 
+    public bool $search_trashed = false;
+
     public array $search_permissions = [];
 
     public Collection $permissionsToSearchable;
@@ -57,6 +59,10 @@ class Index extends Component
                     'permissions',
                     fn (Builder $q) => $q->whereIn('id', $this->search_permissions)
                 )
+            )
+            ->when(
+                $this->search_trashed,
+                fn (Builder $q) => $q->onlyTrashed()
             )
             ->paginate();
     }

--- a/app/Livewire/Admin/Users/Index.php
+++ b/app/Livewire/Admin/Users/Index.php
@@ -7,6 +7,7 @@ use App\Models\{Permission, User};
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Computed;
 use Livewire\{Component, WithPagination, WithoutUrlPagination};
@@ -20,9 +21,12 @@ class Index extends Component
 
     public array $search_permissions = [];
 
+    public Collection $permissionsToSearchable;
+
     public function mount()
     {
         $this->authorize(CanEnum::BE_AN_ADMIN->value);
+        $this->searchPermissions();
     }
 
     public function render(): View
@@ -66,6 +70,17 @@ class Index extends Component
             ['key' => 'email', 'label' => 'Email'],
             ['key' => 'permissions', 'label' => 'Permissions'],
         ];
+    }
+
+    public function searchPermissions(?string $value = '')
+    {
+        $this->permissionsToSearchable = Permission::query()
+            ->when(
+                $value,
+                fn (Builder $q) => $q->where('key', 'like', '%' . $value . '%')
+            )
+            ->orderBy('key')
+            ->get();
     }
 
     #[Computed]

--- a/app/Livewire/Admin/Users/Index.php
+++ b/app/Livewire/Admin/Users/Index.php
@@ -29,6 +29,8 @@ class Index extends Component
 
     public string $sortColumnBy = 'id';
 
+    public int $perPage = 15;
+
     public function mount()
     {
         $this->authorize(CanEnum::BE_AN_ADMIN->value);
@@ -77,7 +79,17 @@ class Index extends Component
                 fn (Builder $q) => $q->onlyTrashed()
             )
             ->orderBy($this->sortColumnBy, $this->sortDirection)
-            ->paginate();
+            ->paginate($this->perPage);
+    }
+
+    #[Computed]
+    public function listPerPages(): array
+    {
+        return [
+            ['id' => 15, 'name' => '15'],
+            ['id' => 30, 'name' => '30'],
+            ['id' => 50, 'name' => '50'],
+        ];
     }
 
     #[Computed]

--- a/app/Livewire/Admin/Users/Index.php
+++ b/app/Livewire/Admin/Users/Index.php
@@ -25,6 +25,10 @@ class Index extends Component
 
     public Collection $permissionsToSearchable;
 
+    public string $sortDirection = 'asc';
+
+    public string $sortColumnBy = 'id';
+
     public function mount()
     {
         $this->authorize(CanEnum::BE_AN_ADMIN->value);
@@ -34,6 +38,14 @@ class Index extends Component
     public function render(): View
     {
         return view('livewire.admin.users.index');
+    }
+
+    // Reset pagination when any component property changes
+    public function updated($property): void
+    {
+        if (!is_array($property) && $property != "") {
+            $this->resetPage();
+        }
     }
 
     public function delete(int $id)
@@ -64,6 +76,7 @@ class Index extends Component
                 $this->search_trashed,
                 fn (Builder $q) => $q->onlyTrashed()
             )
+            ->orderBy($this->sortColumnBy, $this->sortDirection)
             ->paginate();
     }
 
@@ -71,10 +84,10 @@ class Index extends Component
     public function headers(): array
     {
         return [
-            ['key' => 'id', 'label' => '#'],
-            ['key' => 'name', 'label' => 'Name'],
-            ['key' => 'email', 'label' => 'Email'],
-            ['key' => 'permissions', 'label' => 'Permissions'],
+            ['key' => 'id', 'label' => '#', 'sortColumnBy' => $this->sortColumnBy, 'sortDirection' => $this->sortDirection],
+            ['key' => 'name', 'label' => 'Name', 'sortColumnBy' => $this->sortColumnBy, 'sortDirection' => $this->sortDirection],
+            ['key' => 'email', 'label' => 'Email', 'sortColumnBy' => $this->sortColumnBy, 'sortDirection' => $this->sortDirection],
+            ['key' => 'permissions', 'label' => 'Permissions', 'sortColumnBy' => $this->sortColumnBy, 'sortDirection' => $this->sortDirection],
         ];
     }
 
@@ -97,5 +110,11 @@ class Index extends Component
                 'id'   => $permission->id,
                 'name' => $permission->key,
             ])->toArray();
+    }
+
+    public function sortBy(string $column, string $direction): void
+    {
+        $this->sortColumnBy  = $column;
+        $this->sortDirection = $direction;
     }
 }

--- a/app/Livewire/Admin/Users/Index.php
+++ b/app/Livewire/Admin/Users/Index.php
@@ -5,7 +5,9 @@ namespace App\Livewire\Admin\Users;
 use App\Enum\CanEnum;
 use App\Models\User;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Computed;
 use Livewire\{Component, WithPagination, WithoutUrlPagination};
 
@@ -13,6 +15,8 @@ class Index extends Component
 {
     use WithPagination;
     use WithoutUrlPagination;
+
+    public ?string $search = null;
 
     public function mount()
     {
@@ -26,13 +30,20 @@ class Index extends Component
 
     public function delete(int $id)
     {
-
     }
 
     #[Computed]
     public function users(): LengthAwarePaginator
     {
-        return User::query()->with('permissions')->paginate();
+        return User::query()
+            ->with('permissions')
+            ->when($this->search, fn (Builder $q) => $q->where(
+                DB::raw('lower(name)'),
+                'like',
+                '%' . strtolower($this->search) . '%'
+            )
+                ->orWhere('email', 'like', '%' . strtolower($this->search) . '%'))
+            ->paginate();
     }
 
     #[Computed]
@@ -45,4 +56,5 @@ class Index extends Component
             ['key' => 'permissions', 'label' => 'Permissions'],
         ];
     }
+
 }

--- a/app/Livewire/Admin/Users/Index.php
+++ b/app/Livewire/Admin/Users/Index.php
@@ -22,7 +22,7 @@ class Index extends Component
 
     public array $search_permissions = [];
 
-    public Collection $permissionsToSearchable;
+    public Collection $permissionsToSearch;
 
     public string $sortDirection = 'asc';
 
@@ -104,23 +104,13 @@ class Index extends Component
 
     public function searchPermissions(?string $value = '')
     {
-        $this->permissionsToSearchable = Permission::query()
+        $this->permissionsToSearch = Permission::query()
             ->when(
                 $value,
-                fn (Builder $q) => $q->where('key', 'like', '%' . $value . '%')
+                fn (Builder $q) => $q->where('key', 'like', "%$value%")
             )
             ->orderBy('key')
             ->get();
-    }
-
-    #[Computed]
-    public function permissions(): array
-    {
-        return Permission::all()
-            ->map(fn ($permission) => [
-                'id'   => $permission->id,
-                'name' => $permission->key,
-            ])->toArray();
     }
 
     public function sortBy(string $column, string $direction): void

--- a/app/Livewire/Admin/Users/Index.php
+++ b/app/Livewire/Admin/Users/Index.php
@@ -10,12 +10,11 @@ use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Computed;
-use Livewire\{Component, WithPagination, WithoutUrlPagination};
+use Livewire\{Component, WithPagination};
 
 class Index extends Component
 {
     use WithPagination;
-    use WithoutUrlPagination;
 
     public ?string $search = null;
 

--- a/app/Livewire/Admin/Users/Index.php
+++ b/app/Livewire/Admin/Users/Index.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Livewire\Admin\Users;
+
+use App\Enum\CanEnum;
+use App\Models\User;
+use Illuminate\Contracts\View\View;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Livewire\Attributes\Computed;
+use Livewire\{Component, WithPagination, WithoutUrlPagination};
+
+class Index extends Component
+{
+    use WithPagination;
+    use WithoutUrlPagination;
+
+    public function mount()
+    {
+        $this->authorize(CanEnum::BE_AN_ADMIN->value);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.admin.users.index');
+    }
+
+    public function delete(int $id)
+    {
+
+    }
+
+    #[Computed]
+    public function users(): LengthAwarePaginator
+    {
+        return User::query()->with('permissions')->paginate();
+    }
+
+    #[Computed]
+    public function headers(): array
+    {
+        return [
+            ['key' => 'id', 'label' => '#'],
+            ['key' => 'name', 'label' => 'Name'],
+            ['key' => 'email', 'label' => 'Email'],
+            ['key' => 'permissions', 'label' => 'Permissions'],
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\Traits\Models\HasPermission;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -14,6 +15,7 @@ class User extends Authenticatable
     use HasFactory;
     use Notifiable;
     use HasPermission;
+    use SoftDeletes;
 
     protected $fillable = [
         'name',

--- a/app/Traits/Models/HasPermission.php
+++ b/app/Traits/Models/HasPermission.php
@@ -21,20 +21,33 @@ trait HasPermission
         $this->permissions()->firstOrCreate(['key' => $permissionKey]);
 
         Cache::forget($this->permissionCachedKey());
-        Cache::rememberForever($this->permissionCachedKey(), fn () => $this->permissions);
+        Cache::rememberForever(
+            $this->permissionCachedKey(),
+            fn () => $this->permissions
+        );
     }
 
     public function hasPermissionTo(CanEnum|string $key): bool
     {
+
         $permissionKey = $key instanceof CanEnum ? $key->value : $key;
 
-        $permissions = Cache::get($this->permissionCachedKey(), fn () => $this->permissions());
+        $permissions = Cache::get(
+            $this->permissionCachedKey(),
+            function () {
+                return $this->permissions;
+            }
+        );
 
-        return $permissions->where('key', '=', $permissionKey)->count() > 0;
+        return $permissions
+            ->where('key', '=', $permissionKey)
+            ->isNotEmpty();
     }
 
     private function permissionCachedKey(): string
     {
-        return "user::{$this->id}::permissions";
+        $userId = $this->id;
+
+        return "user::{$userId}::permissions";
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "robsontenorio/mary": "^1.35"
     },
     "require-dev": {
+        "barryvdh/laravel-debugbar": "^3.13",
         "fakerphp/faker": "^1.23",
         "laradumps/laradumps": "^3.0",
         "laravel/pint": "^1.13",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5584268c078d9da91082e7bfd274607a",
+    "content-hash": "5847bf0351f1ac2930aac4c9e4226137",
     "packages": [
         {
             "name": "blade-ui-kit/blade-heroicons",
@@ -6231,6 +6231,90 @@
     ],
     "packages-dev": [
         {
+            "name": "barryvdh/laravel-debugbar",
+            "version": "v3.13.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-debugbar.git",
+                "reference": "92d86be45ee54edff735e46856f64f14b6a8bb07"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-debugbar/zipball/92d86be45ee54edff735e46856f64f14b6a8bb07",
+                "reference": "92d86be45ee54edff735e46856f64f14b6a8bb07",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/routing": "^9|^10|^11",
+                "illuminate/session": "^9|^10|^11",
+                "illuminate/support": "^9|^10|^11",
+                "maximebf/debugbar": "~1.22.0",
+                "php": "^8.0",
+                "symfony/finder": "^6|^7"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3.3",
+                "orchestra/testbench-dusk": "^5|^6|^7|^8|^9",
+                "phpunit/phpunit": "^9.6|^10.5",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.13-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Barryvdh\\Debugbar\\ServiceProvider"
+                    ],
+                    "aliases": {
+                        "Debugbar": "Barryvdh\\Debugbar\\Facades\\Debugbar"
+                    }
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Barryvdh\\Debugbar\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "PHP Debugbar integration for Laravel",
+            "keywords": [
+                "debug",
+                "debugbar",
+                "laravel",
+                "profiler",
+                "webprofiler"
+            ],
+            "support": {
+                "issues": "https://github.com/barryvdh/laravel-debugbar/issues",
+                "source": "https://github.com/barryvdh/laravel-debugbar/tree/v3.13.5"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-04-12T11:20:37+00:00"
+        },
+        {
             "name": "brianium/paratest",
             "version": "v7.4.3",
             "source": {
@@ -6945,6 +7029,74 @@
                 "source": "https://github.com/laravel/sail"
             },
             "time": "2024-08-02T07:45:47+00:00"
+        },
+        {
+            "name": "maximebf/debugbar",
+            "version": "v1.22.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maximebf/php-debugbar.git",
+                "reference": "7aa9a27a0b1158ed5ad4e7175e8d3aee9a818b96"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maximebf/php-debugbar/zipball/7aa9a27a0b1158ed5ad4e7175e8d3aee9a818b96",
+                "reference": "7aa9a27a0b1158ed5ad4e7175e8d3aee9a818b96",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8",
+                "psr/log": "^1|^2|^3",
+                "symfony/var-dumper": "^4|^5|^6|^7"
+            },
+            "require-dev": {
+                "dbrekelmans/bdi": "^1",
+                "phpunit/phpunit": "^8|^9",
+                "symfony/panther": "^1|^2.1",
+                "twig/twig": "^1.38|^2.7|^3.0"
+            },
+            "suggest": {
+                "kriswallsmith/assetic": "The best way to manage assets",
+                "monolog/monolog": "Log using Monolog",
+                "predis/predis": "Redis storage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.22-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DebugBar\\": "src/DebugBar/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maxime Bouroumeau-Fuseau",
+                    "email": "maxime.bouroumeau@gmail.com",
+                    "homepage": "http://maximebf.com"
+                },
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Debug bar in the browser for php application",
+            "homepage": "https://github.com/maximebf/php-debugbar",
+            "keywords": [
+                "debug",
+                "debugbar"
+            ],
+            "support": {
+                "issues": "https://github.com/maximebf/php-debugbar/issues",
+                "source": "https://github.com/maximebf/php-debugbar/tree/v1.22.3"
+            },
+            "time": "2024-04-03T19:39:26+00:00"
         },
         {
             "name": "mockery/mockery",

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -48,4 +48,9 @@ class UserFactory extends Factory
     {
         return $this->afterCreating(fn (User $user) => $user->givePermissionTo($permission));
     }
+
+    public function admin(): static
+    {
+        return $this->afterCreating(fn (User $user) => $user->givePermissionTo(CanEnum::BE_AN_ADMIN));
+    }
 }

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -18,6 +18,8 @@ return new class () extends Migration {
             $table->string('password');
             $table->rememberToken();
             $table->timestamps();
+            $table->softDeletes();
+
         });
 
         Schema::create('password_reset_tokens', function (Blueprint $table) {

--- a/database/migrations/2024_08_24_200142_create_permissions_table.php
+++ b/database/migrations/2024_08_24_200142_create_permissions_table.php
@@ -16,7 +16,6 @@ return new class () extends Migration {
         Schema::create('permission_user', function (Blueprint $table) {
             $table->foreignId('user_id');
             $table->foreignId('permission_id');
-            $table->index(['user_id', 'permission_id']);
             $table->unique(['user_id', 'permission_id']);
         });
     }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -10,6 +10,7 @@ class UserSeeder extends Seeder
 {
     public function run(): void
     {
+
         User::factory()
             ->withPermission(CanEnum::BE_AN_ADMIN)
             ->create([
@@ -22,5 +23,7 @@ class UserSeeder extends Seeder
                 'name'  => 'John Doe',
                 'email' => 'test@example.com',
             ]);
+
+        User::factory()->count(50)->create();
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -24,6 +24,14 @@ class UserSeeder extends Seeder
                 'email' => 'test@example.com',
             ]);
 
-        User::factory()->count(50)->create();
+        User::factory()->count(20)->create();
+        User::factory()->count(5)
+            ->sequence(
+                ['deleted_at' => now()->subMinutes(random_int(1, 5))],
+                [
+                    'deleted_at' => now()->subMinutes(random_int(1, 5)),
+                ]
+            )
+            ->create();
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -24,7 +24,7 @@ class UserSeeder extends Seeder
                 'email' => 'test@example.com',
             ]);
 
-        User::factory()->count(20)->create();
+        User::factory()->count(50)->create();
         User::factory()->count(5)
             ->sequence(
                 ['deleted_at' => now()->subMinutes(random_int(1, 5))],

--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -53,7 +53,8 @@
                 @can(\App\Enum\CanEnum::BE_AN_ADMIN->value)
                     <x-menu-sub title="Admin" icon="o-cog-6-tooth">
                         <x-menu-item title="Dashboard" icon="o-chart-bar-square" :link="route('admin.dashboard')" />
-                        <x-menu-item title="Archives" icon="o-archive-box" link="####" />
+                        <x-menu-item title="Users" icon="o-users" :link="route('admin.users')" />
+
                     </x-menu-sub>
                 @endcan
             </x-menu>
@@ -61,7 +62,9 @@
 
         {{-- The `$slot` goes here --}}
         <x-slot:content>
-            {{ $slot }}
+            <div class="p-5">
+                {{ $slot }}
+            </div>
         </x-slot:content>
     </x-main>
 

--- a/resources/views/components/table/th-label.blade.php
+++ b/resources/views/components/table/th-label.blade.php
@@ -1,0 +1,11 @@
+@props(['header', 'name'])
+
+@php
+    $direction = $header['sortDirection'] == 'asc' ? 'desc' : 'asc';
+@endphp
+
+<div {{ $attributes->class(['cursor-pointer']) }} wire:click="sortBy('{{ $name }}', '{{ $direction }}')">
+    {{ $header['label'] }} @if ($header['sortColumnBy'] == $name)
+        <x-icon :name="$header['sortDirection'] == 'asc' ? 'o-chevron-up' : 'o-chevron-down'" class="w-3 h-3 ml-px" />
+    @endif
+</div>

--- a/resources/views/livewire/admin/dashboard.blade.php
+++ b/resources/views/livewire/admin/dashboard.blade.php
@@ -1,3 +1,4 @@
 <div>
+    <x-header title="Admin Dashboard" separator />
     <h1>Admin Dashboard</h1>
 </div>

--- a/resources/views/livewire/admin/users/index.blade.php
+++ b/resources/views/livewire/admin/users/index.blade.php
@@ -60,5 +60,7 @@
 
     </x-table>
 
-    {{ $this->users->links(data: ['scrollTo' => false]) }}
+    <div class="mt-7">
+        {{ $this->users->links(data: ['scrollTo' => false]) }}
+    </div>
 </div>

--- a/resources/views/livewire/admin/users/index.blade.php
+++ b/resources/views/livewire/admin/users/index.blade.php
@@ -2,6 +2,13 @@
 
     <x-header title="Users" separator />
 
+    <div class="flex mb-5 space-x-4">
+        <div class="w-1/3">
+            <x-input placeholder="Search by email and name" icon="o-magnifying-glass"
+                wire:model.live.debounce.300ms="search" />
+        </div>
+    </div>
+
     {{-- You can use any `$wire.METHOD` on `@row-click` --}}
     <x-table :headers="$this->headers" :rows="$this->users" with-pagination striped>
 

--- a/resources/views/livewire/admin/users/index.blade.php
+++ b/resources/views/livewire/admin/users/index.blade.php
@@ -9,7 +9,7 @@
 
         <div class="min-w-52">
             <x-choices label="Serch by permissions" placeholder="Permissions" wire:model.live="search_permissions"
-                :options="$permissionsToSearchable" search-function="searchPermissions" searchable option-label="key"
+                :options="$permissionsToSearch" search-function="searchPermissions" searchable option-label="key"
                 no-result-text="Nothing here" />
 
         </div>

--- a/resources/views/livewire/admin/users/index.blade.php
+++ b/resources/views/livewire/admin/users/index.blade.php
@@ -15,15 +15,17 @@
 
         </div>
 
-        <div>
-            <x-checkbox label="Show deleted users" wire:model.live="search_trashed" right tight />
-        </div>
+
+        <x-checkbox label="Show deleted users" wire:model.live="search_trashed" right tight />
+
+        <x-select label="Records per page" :options="$this->listPerPages" wire:model.live="perPage" />
+
 
 
     </div>
 
     {{-- You can use any `$wire.METHOD` on `@row-click` --}}
-    <x-table :headers="$this->headers" :rows="$this->users" with-pagination striped>
+    <x-table :headers="$this->headers" :rows="$this->users" striped>
 
         @scope('header_id', $header)
             <x-table.th-label name="id" :$header class="select-none" />
@@ -59,4 +61,6 @@
         @endscope
 
     </x-table>
+
+    {{ $this->users->links() }}
 </div>

--- a/resources/views/livewire/admin/users/index.blade.php
+++ b/resources/views/livewire/admin/users/index.blade.php
@@ -1,0 +1,25 @@
+<div>
+
+    <x-header title="Users" separator />
+
+    {{-- You can use any `$wire.METHOD` on `@row-click` --}}
+    <x-table :headers="$this->headers" :rows="$this->users" with-pagination striped>
+
+        @scope('cell_permissions', $user)
+            @if ($user->permissions->count())
+                @foreach ($user->permissions as $permission)
+                    <x-badge :value="$permission->key" class="badge-sm badge-primary" />
+                @endforeach
+            @else
+                <x-badge value="None" class="badge-sm badge-badge-ghost" />
+            @endif
+        @endscope
+
+
+        {{-- Special `actions` slot --}}
+        @scope('actions', $user)
+            <x-button icon="o-trash" wire:click="delete({{ $user->id }})" spinner class="btn-ghost btn-sm" />
+        @endscope
+
+    </x-table>
+</div>

--- a/resources/views/livewire/admin/users/index.blade.php
+++ b/resources/views/livewire/admin/users/index.blade.php
@@ -4,12 +4,14 @@
 
     <div class="flex mb-5 space-x-4">
         <div class="w-1/3">
-            <x-input placeholder="Search by email and name" icon="o-magnifying-glass"
+            <x-input label="Search by email and name" placeholder="Search by email and name" icon="o-magnifying-glass"
                 wire:model.live.debounce.300ms="search" />
         </div>
 
         <div class="w-1/6">
-            <x-choices placeholder="Permissions" wire:model.live="search_permissions" :options="$this->permissions" />
+            <x-choices label="Serch by permissions" placeholder="Permissions" wire:model.live="search_permissions" :options="$permissionsToSearchable"
+                search-function="searchPermissions" searchable option-label="key" no-result-text="Nothing here" />
+
         </div>
 
     </div>

--- a/resources/views/livewire/admin/users/index.blade.php
+++ b/resources/views/livewire/admin/users/index.blade.php
@@ -7,6 +7,11 @@
             <x-input placeholder="Search by email and name" icon="o-magnifying-glass"
                 wire:model.live.debounce.300ms="search" />
         </div>
+
+        <div class="w-1/6">
+            <x-choices placeholder="Permissions" wire:model.live="search_permissions" :options="$this->permissions" />
+        </div>
+
     </div>
 
     {{-- You can use any `$wire.METHOD` on `@row-click` --}}

--- a/resources/views/livewire/admin/users/index.blade.php
+++ b/resources/views/livewire/admin/users/index.blade.php
@@ -2,17 +2,23 @@
 
     <x-header title="Users" separator />
 
-    <div class="flex mb-5 space-x-4">
+    <div class="flex mb-5 space-x-4 place-items-center">
         <div class="w-1/3">
             <x-input label="Search by email and name" placeholder="Search by email and name" icon="o-magnifying-glass"
                 wire:model.live.debounce.300ms="search" />
         </div>
 
-        <div class="w-1/6">
-            <x-choices label="Serch by permissions" placeholder="Permissions" wire:model.live="search_permissions" :options="$permissionsToSearchable"
-                search-function="searchPermissions" searchable option-label="key" no-result-text="Nothing here" />
+        <div class="min-w-52">
+            <x-choices label="Serch by permissions" placeholder="Permissions" wire:model.live="search_permissions"
+                :options="$permissionsToSearchable" search-function="searchPermissions" searchable option-label="key"
+                no-result-text="Nothing here" />
 
         </div>
+
+        <div>
+            <x-checkbox label="Show deleted users" wire:model.live="search_trashed" right tight />
+        </div>
+
 
     </div>
 
@@ -30,9 +36,13 @@
         @endscope
 
 
-        {{-- Special `actions` slot --}}
         @scope('actions', $user)
-            <x-button icon="o-trash" wire:click="delete({{ $user->id }})" spinner class="btn-ghost btn-sm" />
+            @unless ($user->trashed())
+                <x-button icon="o-trash" wire:click="delete({{ $user->id }})" spinner class="btn-ghost btn-sm" />
+            @else
+                <x-button title="Restore" icon="o-arrow-uturn-left" wire:click="restore({{ $user->id }})" spinner
+                    class="btn-ghost btn-sm" />
+            @endunless
         @endscope
 
     </x-table>

--- a/resources/views/livewire/admin/users/index.blade.php
+++ b/resources/views/livewire/admin/users/index.blade.php
@@ -25,6 +25,19 @@
     {{-- You can use any `$wire.METHOD` on `@row-click` --}}
     <x-table :headers="$this->headers" :rows="$this->users" with-pagination striped>
 
+        @scope('header_id', $header)
+            <x-table.th-label name="id" :$header class="select-none" />
+        @endscope
+
+        @scope('header_name', $header)
+            <x-table.th-label name="name" :$header class="select-none" />
+        @endscope
+
+        @scope('header_email', $header)
+            <x-table.th-label name="email" :$header class="select-none" />
+        @endscope
+
+
         @scope('cell_permissions', $user)
             @if ($user->permissions->count())
                 @foreach ($user->permissions as $permission)

--- a/resources/views/livewire/admin/users/index.blade.php
+++ b/resources/views/livewire/admin/users/index.blade.php
@@ -1,5 +1,4 @@
 <div>
-
     <x-header title="Users" separator />
 
     <div class="flex mb-5 space-x-4 place-items-center">
@@ -24,8 +23,7 @@
 
     </div>
 
-    {{-- You can use any `$wire.METHOD` on `@row-click` --}}
-    <x-table :headers="$this->headers" :rows="$this->users" striped>
+    <x-table :headers="$this->headers" :rows="$this->users">
 
         @scope('header_id', $header)
             <x-table.th-label name="id" :$header class="select-none" />
@@ -62,5 +60,5 @@
 
     </x-table>
 
-    {{ $this->users->links() }}
+    {{ $this->users->links(data: ['scrollTo' => false]) }}
 </div>

--- a/resources/views/livewire/welcome.blade.php
+++ b/resources/views/livewire/welcome.blade.php
@@ -1,6 +1,6 @@
 <div>
     <!-- HEADER -->
-    <x-header title="App" separator progress-indicator>
+    <x-header title="Matrizes" separator progress-indicator>
         <x-slot:middle class="!justify-end">
             <x-input placeholder="Search..." wire:model.live.debounce="search" clearable icon="o-magnifying-glass" />
         </x-slot:middle>
@@ -13,7 +13,7 @@
     <x-card>
         <x-table :headers="$headers" :rows="$users" :sort-by="$sortBy">
             @scope('actions', $user)
-            <x-button icon="o-trash" wire:click="delete({{ $user['id'] }})" spinner class="text-red-500 btn-ghost btn-sm" />
+            <x-button icon="o-trash" wire:click="delete({{ $user['id'] }})" spinner class="btn-ghost btn-sm" />
             @endscope
         </x-table>
     </x-card>

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,8 @@ Route::group(['middleware' => 'auth'], function () {
     //region Admin
     Route::prefix('admin')->middleware('can:' . CanEnum::BE_AN_ADMIN->value)->group(function () {
         Route::get('/dashboard', Admin\Dashboard::class)->name('admin.dashboard');
+
+        Route::get('/users', fn () => 'oi')->name('admin.users');
     });
     //endregion
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,8 +21,7 @@ Route::group(['middleware' => 'auth'], function () {
     //region Admin
     Route::prefix('admin')->middleware('can:' . CanEnum::BE_AN_ADMIN->value)->group(function () {
         Route::get('/dashboard', Admin\Dashboard::class)->name('admin.dashboard');
-
-        Route::get('/users', fn () => 'oi')->name('admin.users');
+        Route::get('/users', Admin\Users\Index::class)->name('admin.users');
     });
     //endregion
 

--- a/storage/debugbar/.gitignore
+++ b/storage/debugbar/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,7 @@ export default {
         "./resources/**/*.js",
         "./app/View/Components/**/*.php",
         "./app/Livewire/**/*.php",
+        "./vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php",
         // Mary UI
         "./vendor/robsontenorio/mary/src/View/Components/**/*.php",
     ],

--- a/tests/Feature/UserManagement/ListUsersTest.php
+++ b/tests/Feature/UserManagement/ListUsersTest.php
@@ -1,7 +1,8 @@
 <?php
 
+use App\Enum\CanEnum;
 use App\Livewire\Admin;
-use App\Models\User;
+use App\Models\{Permission, User};
 use Illuminate\Pagination\LengthAwarePaginator;
 use Livewire\Livewire;
 
@@ -79,6 +80,29 @@ it('should be able to filter by name or email', function () {
             expect($users)
                 ->toHaveCount(1)
                 ->first()->name->toBe('Kira');
+
+            return true;
+        });
+});
+
+it('should be able to filter by permission key', function () {
+    $admin      = User::factory()->admin()->create(['name' => 'Joe Doe', 'email' => 'j@j.com']);
+    $permission = Permission::where('key', CanEnum::BE_AN_ADMIN->value)->first();
+    User::factory()->create(['name' => 'Kira', 'email' => 'rntok@k.com']);
+
+    actingAs($admin);
+
+    Livewire::test(Admin\Users\Index::class)
+        ->assertSet('users', function ($users) {
+            expect($users)
+                ->toHaveCount(2);
+
+            return true;
+        })->set('search_permissions', [$permission->id])
+        ->assertSet('users', function ($users) {
+            expect($users)
+                ->toHaveCount(1)
+                ->first()->name->toBe('Joe Doe');
 
             return true;
         });

--- a/tests/Feature/UserManagement/ListUsersTest.php
+++ b/tests/Feature/UserManagement/ListUsersTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Livewire\Admin;
 use App\Models\User;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Livewire\Livewire;
 
 use function Pest\Laravel\actingAs;
 
@@ -16,4 +19,37 @@ it('making sure that the route is protected by permission BE_AN_ADMIN', function
     $user = User::factory()->create();
 
     actingAs($user)->get(route('admin.users'))->assertForbidden();
+});
+
+test('livewire component to list users in the page', function () {
+
+    actingAs(User::factory()->admin()->create());
+    $users = User::factory()->count(10)->create();
+
+    $livewire = Livewire::test(Admin\Users\Index::class);
+
+    $livewire->assertSet('users', function ($users) {
+        expect($users)
+            ->toBeInstanceOf(LengthAwarePaginator::class)
+            ->toHaveCount(11);
+
+        return true;
+    });
+
+    foreach ($users as $user) {
+        $livewire->assertSee($user->name);
+    }
+});
+
+test('checking a table format', function () {
+
+    actingAs(User::factory()->admin()->create());
+
+    Livewire::test(Admin\Users\Index::class)
+        ->assertSet('headers', [
+            ['key' => 'id', 'label' => '#'],
+            ['key' => 'name', 'label' => 'Name'],
+            ['key' => 'email', 'label' => 'Email'],
+            ['key' => 'permissions', 'label' => 'Permissions'],
+        ]);
 });

--- a/tests/Feature/UserManagement/ListUsersTest.php
+++ b/tests/Feature/UserManagement/ListUsersTest.php
@@ -86,8 +86,8 @@ it('should be able to filter by name or email', function () {
 });
 
 it('should be able to filter by permission key', function () {
-    $admin   = User::factory()->admin()->create(['name' => 'Joe Doe', 'email' => 'j@j.com']);
-    $noAdmin = User::factory()->withPermission(CanEnum::BE_AN_USER)
+    $admin = User::factory()->admin()->create(['name' => 'Joe Doe', 'email' => 'j@j.com']);
+    User::factory()->withPermission(CanEnum::BE_AN_USER)
         ->create(['name' => 'No Admin', 'email' => 'noadmin@noadm.com']);
 
     $permissionAnAdmin = Permission::where('key', CanEnum::BE_AN_ADMIN->value)->first();
@@ -106,6 +106,30 @@ it('should be able to filter by permission key', function () {
             expect($users)
                 ->toHaveCount(2)
                 ->first()->name->toBe('Joe Doe');
+
+            return true;
+        });
+});
+
+it('should be list deleted users', function () {
+    $admin = User::factory()->admin()->create(['name' => 'Joe Doe', 'email' => 'admin@admin.com']);
+    User::factory()->count(2)->create([
+        'deleted_at' => now(),
+    ]);
+
+    actingAs($admin);
+
+    Livewire::test(Admin\Users\Index::class)
+        ->assertSet('users', function ($users) {
+            expect($users)
+                ->toHaveCount(1);
+
+            return true;
+        })
+        ->set('search_trashed', true)
+        ->assertSet('users', function ($users) {
+            expect($users)
+                ->toHaveCount(2);
 
             return true;
         });

--- a/tests/Feature/UserManagement/ListUsersTest.php
+++ b/tests/Feature/UserManagement/ListUsersTest.php
@@ -86,9 +86,12 @@ it('should be able to filter by name or email', function () {
 });
 
 it('should be able to filter by permission key', function () {
-    $admin      = User::factory()->admin()->create(['name' => 'Joe Doe', 'email' => 'j@j.com']);
-    $permission = Permission::where('key', CanEnum::BE_AN_ADMIN->value)->first();
-    User::factory()->create(['name' => 'Kira', 'email' => 'rntok@k.com']);
+    $admin   = User::factory()->admin()->create(['name' => 'Joe Doe', 'email' => 'j@j.com']);
+    $noAdmin = User::factory()->withPermission(CanEnum::BE_AN_USER)
+        ->create(['name' => 'No Admin', 'email' => 'noadmin@noadm.com']);
+
+    $permissionAnAdmin = Permission::where('key', CanEnum::BE_AN_ADMIN->value)->first();
+    $permissionAnUser  = Permission::where('key', CanEnum::BE_AN_USER->value)->first();
 
     actingAs($admin);
 
@@ -98,10 +101,10 @@ it('should be able to filter by permission key', function () {
                 ->toHaveCount(2);
 
             return true;
-        })->set('search_permissions', [$permission->id])
+        })->set('search_permissions', [$permissionAnAdmin->id, $permissionAnUser->id])
         ->assertSet('users', function ($users) {
             expect($users)
-                ->toHaveCount(1)
+                ->toHaveCount(2)
                 ->first()->name->toBe('Joe Doe');
 
             return true;

--- a/tests/Feature/UserManagement/ListUsersTest.php
+++ b/tests/Feature/UserManagement/ListUsersTest.php
@@ -9,3 +9,11 @@ it('should be able to access the route admin/users', function () {
 
     actingAs($user)->get(route('admin.users'))->assertOk();
 });
+
+it('making sure that the route is protected by permission BE_AN_ADMIN', function () {
+
+    /** @var User $user */
+    $user = User::factory()->create();
+
+    actingAs($user)->get(route('admin.users'))->assertForbidden();
+});

--- a/tests/Feature/UserManagement/ListUsersTest.php
+++ b/tests/Feature/UserManagement/ListUsersTest.php
@@ -166,3 +166,23 @@ it('should be able to sort by name', function () {
             return true;
         });
 });
+
+it('should be able paginate the result', function () {
+
+    $admin = User::factory()->admin()->create(['name' => 'Joe Doe', 'email' => 'jd@jd.com']);
+    User::factory()->count(30)->create();
+
+    actingAs($admin);
+
+    Livewire::test(Admin\Users\Index::class)
+        ->assertSet('users', function (LengthAwarePaginator $users) {
+            expect($users)->toHaveCount(15);
+
+            return true;
+        })->set('perPage', 20)
+        ->assertSet('users', function (LengthAwarePaginator $users) {
+            expect($users)->toHaveCount(20);
+
+            return true;
+        });
+});

--- a/tests/Feature/UserManagement/ListUsersTest.php
+++ b/tests/Feature/UserManagement/ListUsersTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Models\User;
+
+use function Pest\Laravel\actingAs;
+
+it('should be able to access the route admin/users', function () {
+    $user = User::factory()->admin()->create();
+
+    actingAs($user)->get(route('admin.users'))->assertOk();
+});

--- a/tests/Feature/UserManagement/ListUsersTest.php
+++ b/tests/Feature/UserManagement/ListUsersTest.php
@@ -53,3 +53,33 @@ test('checking a table format', function () {
             ['key' => 'permissions', 'label' => 'Permissions'],
         ]);
 });
+
+it('should be able to filter by name or email', function () {
+    $admin = User::factory()->admin()->create(['name' => 'Joe Doe', 'email' => 'j@j.com']);
+    User::factory()->create(['name' => 'Kira', 'email' => 'rntok@k.com']);
+
+    actingAs($admin);
+
+    Livewire::test(Admin\Users\Index::class)
+        ->assertSet('users', function ($users) {
+            expect($users)
+                ->toHaveCount(2);
+
+            return true;
+        })->set('search', 'kira')
+        ->assertSet('users', function ($users) {
+            expect($users)
+                ->toHaveCount(1)
+                ->first()->name->toBe('Kira');
+
+            return true;
+        })
+        ->set('search', 'rntok')
+        ->assertSet('users', function ($users) {
+            expect($users)
+                ->toHaveCount(1)
+                ->first()->name->toBe('Kira');
+
+            return true;
+        });
+});

--- a/tests/Feature/UserManagement/ListUsersTest.php
+++ b/tests/Feature/UserManagement/ListUsersTest.php
@@ -48,15 +48,15 @@ test('checking a table format', function () {
 
     Livewire::test(Admin\Users\Index::class)
         ->assertSet('headers', [
-            ['key' => 'id', 'label' => '#'],
-            ['key' => 'name', 'label' => 'Name'],
-            ['key' => 'email', 'label' => 'Email'],
-            ['key' => 'permissions', 'label' => 'Permissions'],
+            ['key' => 'id', 'label' => '#', 'sortColumnBy' => 'id', 'sortDirection' => 'asc'],
+            ['key' => 'name', 'label' => 'Name',   'sortColumnBy' => 'id', 'sortDirection' => 'asc'],
+            ['key' => 'email', 'label' => 'Email', 'sortColumnBy' => 'id', 'sortDirection' => 'asc'],
+            ['key' => 'permissions', 'label' => 'Permissions', 'sortColumnBy' => 'id', 'sortDirection' => 'asc'],
         ]);
 });
 
 it('should be able to filter by name or email', function () {
-    $admin = User::factory()->admin()->create(['name' => 'Joe Doe', 'email' => 'j@j.com']);
+    $admin = User::factory()->admin()->create(['name' => 'Joe Doe', 'email' => 'jd@jd.com']);
     User::factory()->create(['name' => 'Kira', 'email' => 'rntok@k.com']);
 
     actingAs($admin);
@@ -86,7 +86,7 @@ it('should be able to filter by name or email', function () {
 });
 
 it('should be able to filter by permission key', function () {
-    $admin = User::factory()->admin()->create(['name' => 'Joe Doe', 'email' => 'j@j.com']);
+    $admin = User::factory()->admin()->create(['name' => 'Joe Doe', 'email' => 'jd@jd.com']);
     User::factory()->withPermission(CanEnum::BE_AN_USER)
         ->create(['name' => 'No Admin', 'email' => 'noadmin@noadm.com']);
 
@@ -130,6 +130,38 @@ it('should be list deleted users', function () {
         ->assertSet('users', function ($users) {
             expect($users)
                 ->toHaveCount(2);
+
+            return true;
+        });
+});
+
+it('should be able to sort by name', function () {
+    $admin = User::factory()->admin()->create(['name' => 'Joe Doe', 'email' => 'jd@jd.com']);
+    User::factory()->withPermission(CanEnum::BE_AN_USER)
+        ->create(['name' => 'No Admin', 'email' => 'noadmin@noadm.com']);
+
+    actingAs($admin);
+
+    Livewire::test(Admin\Users\Index::class)
+        ->set('sortDirection', 'desc')
+        ->set('sortColumnBy', 'name')
+        ->assertSet('users', function ($users) {
+            expect($users)
+                ->first()->name->toBe('No Admin')
+                ->and($users)
+                ->last()->name->toBe('Joe Doe');
+
+            return true;
+        });
+
+    Livewire::test(Admin\Users\Index::class)
+        ->set('sortDirection', 'asc')
+        ->set('sortColumnBy', 'name')
+        ->assertSet('users', function ($users) {
+            expect($users)
+                ->first()->name->toBe('Joe Doe')
+                ->and($users)
+                ->last()->name->toBe('No Admin');
 
             return true;
         });


### PR DESCRIPTION
- should be able to access the route admin/user
- making sure that the route is protected by permission BE_AN_ADMIN
- setting up the frontend of the table users
- be able to filter users by name and email
- be able to filter by permission key in table users
- remove unnecessary index in schema permission_user
- label in fieds frontend Users
- backend: filtering deleted users
- frontend: filter by trashed users
- sort by name,id and email
- paginate select
- installing debugbar
- references Laravel's pagination views so that their Tailwind classes are not purged
- fix: hasPermissionTo
- change choice options variable name
